### PR TITLE
don't show address for previous events

### DIFF
--- a/src/@matthieuauger/gatsby-theme-meetup/components/Meetup/Meetup.component.js
+++ b/src/@matthieuauger/gatsby-theme-meetup/components/Meetup/Meetup.component.js
@@ -32,7 +32,11 @@ const Meetup = ({
             <div className="meetup-informations-basic-highlight">
               {meetupInfo.venue.name}
             </div>
-            <div>{meetupInfo.venue.address_1}</div>
+
+            {meetupType === 'UPCOMING' && (
+              <div>{meetupInfo.venue.address_1}</div>
+            )}
+
             <div>{meetupInfo.venue.city}</div>
           </div>
         </div>


### PR DESCRIPTION
Updated to not show the street address for previous events as it adds clutter but not much value imo