### PR TITLE
Temporarily increase meetup event description limit 

### DIFF
--- a/src/@matthieuauger/gatsby-theme-meetup/components/Meetup/Meetup.component.js
+++ b/src/@matthieuauger/gatsby-theme-meetup/components/Meetup/Meetup.component.js
@@ -51,7 +51,7 @@ const Meetup = ({
           <div
             className="meetup-informations-talks"
             dangerouslySetInnerHTML={{
-              __html: meetupInfo.description.slice(0, 250) + '...',
+              __html: meetupInfo.description.slice(0, 300) + '...',
             }}
           />
         )}


### PR DESCRIPTION
Temporarily increase the character limit for event descriptions until the logic is updated to prevent the rendering bug mentioned in this ticket: https://github.com/M0nica/React-Ladies/issues/35